### PR TITLE
Remove obsolete check in CommandHandler

### DIFF
--- a/Modules/CommandHandler.cs
+++ b/Modules/CommandHandler.cs
@@ -50,8 +50,7 @@ namespace BrackeysBot.Modules
 
             int argPos = 0;
 
-            if (!msg.HasStringPrefix(CommandPrefix, ref argPos)
-                && !msg.Content.ToLower().StartsWith("thank")) return;
+            if (!msg.HasStringPrefix(CommandPrefix, ref argPos)) return;
 
             CommandContext context = new CommandContext(client, msg);
 


### PR DESCRIPTION
We don't use points anymore, so this line does a command lookup in vain every time someone writes "thanks". This PR will solve that.