### PR TITLE
Change custom command handling

### DIFF
--- a/Data/CooldownData.cs
+++ b/Data/CooldownData.cs
@@ -14,6 +14,7 @@ namespace BrackeysBot
         {
             return JsonConvert.DeserializeObject<CooldownData>(File.ReadAllText(path));
         }
+
         public void Save(string path)
         {
             File.WriteAllText("cooldowns.json", JsonConvert.SerializeObject(this, Formatting.Indented));

--- a/Modules/CommandHandler.cs
+++ b/Modules/CommandHandler.cs
@@ -68,7 +68,8 @@ namespace BrackeysBot.Modules
             catch
             {
                 // The executed command wasnt found in the modules, therefore look if any custom commands are registered.
-                string command = msg.Content.Substring(argPos);
+
+                string command = msg.Content.Substring(argPos).Split(' ')[0];
                 if (_data.CustomCommands.Has(command))
                 {
                     string message = _data.CustomCommands.Get(command);


### PR DESCRIPTION
Previously, the bot would not respond with anything if a user wrote
"[]customCommand @LeMorrow"
because that string does not match the custom command.

This pull request will make it send the command properly.