### PR TITLE
Using the short pastemyst url

### DIFF
--- a/Commands/PasteCommand.cs
+++ b/Commands/PasteCommand.cs
@@ -93,7 +93,7 @@ namespace BrackeysBot.Commands
             response.EnsureSuccessStatusCode ();
             string json = await response.Content.ReadAsStringAsync ();
             PasteMystResultInfo result = JsonConvert.DeserializeObject<PasteMystResultInfo> (json);
-            return $"{new Uri (new Uri (PASTEMYST_BASE_URL), "paste")}?id={result.Id}";
+            return new Uri (new Uri (PASTEMYST_BASE_URL), result.Id).ToString ();
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #154 

Instead of using https://paste.myst.rs/paste?id=hou it uses https://paste.myst.rs/hou