### PR TITLE
Add []math command

### DIFF
--- a/src/BrackeysBot.csproj
+++ b/src/BrackeysBot.csproj
@@ -13,8 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CSharpMath" Version="0.4.2" />
+    <PackageReference Include="CSharpMath.SkiaSharp" Version="0.4.2" />
     <PackageReference Include="Discord.Net" Version="2.1.1" />
     <PackageReference Include="Humanizer.Core" Version="2.7.9" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Commands/Modules/Utility/MathCommand.cs
+++ b/src/Commands/Modules/Utility/MathCommand.cs
@@ -1,0 +1,66 @@
+﻿namespace BrackeysBot.Commands
+{
+    using System.Drawing;
+    using System.Drawing.Drawing2D;
+    using System.Drawing.Imaging;
+    using System.IO;
+    using System.Threading.Tasks;
+    using CSharpMath.SkiaSharp;
+    using Discord.Commands;
+    using SkiaSharp;
+
+    public partial class UtilityModule : BrackeysBotModule
+    {
+        [Command("math"), Alias("maths", "eq", "equation", "tex", "latex")]
+        [Summary("Renders LaTeX input to an image, and attaches the result.")]
+        public async Task MathCommandAsync([Summary("The LaTeX input."), Remainder]
+                                           string input)
+        {
+            using var originalImage = Render(input);
+            using var image = AddPadding(originalImage, 20);
+            using var resized = Resize(image, image.Size / 2);
+            await using var stream = GetImageStream(resized);
+
+            await Context.Channel.SendFileAsync(stream, "equation.png");
+        }
+
+        private static Image Resize(Image image, Size newSize)
+        {
+            var bitmap = new Bitmap(newSize.Width, newSize.Height);
+            using var graphics = Graphics.FromImage(bitmap);
+            
+            graphics.SmoothingMode = SmoothingMode.HighQuality;
+            graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+            
+            graphics.DrawImage(image, new Rectangle(Point.Empty, newSize));
+            graphics.Flush();
+            return bitmap;
+        }
+
+        private static Stream GetImageStream(Image image)
+        {
+            var stream = new MemoryStream();
+            image.Save(stream, ImageFormat.Png);
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static Image Render(string input)
+        {
+            var painter = new MathPainter { LaTeX = input };
+            var stream = painter.DrawAsStream(format: SKEncodedImageFormat.Png);
+            return Image.FromStream(stream);
+        }
+
+        private static Image AddPadding(Image original, int padding = 10)
+        {
+            var bitmap = new Bitmap(original.Width + padding * 2, original.Height + padding * 2);
+            using var graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(System.Drawing.Color.White);
+            graphics.DrawImage(original, new Point(padding, padding));
+            graphics.Flush();
+            return bitmap;
+        }
+    }
+}


### PR DESCRIPTION
Bot replies with the rendered result as an image attachment.

Dependencies added:
- CSharpMath
- CSharpMath.SkiasHARP
- System.Drawing.Common

Current aliases: `maths`, `eq`, `equation`, `tex`, `latex`

![image](https://user-images.githubusercontent.com/1129769/95764075-dbb3d680-0ca7-11eb-8c22-24645c27028c.png)
