### PR TITLE
Only update timeout on successful LaTeX render

### DIFF
--- a/src/Commands/Modules/Utility/MathCommand.cs
+++ b/src/Commands/Modules/Utility/MathCommand.cs
@@ -31,8 +31,6 @@ namespace BrackeysBot.Commands
             if (!canOverride && remaining > 0)
                 throw new TimeoutException($"You need to wait {TimeSpan.FromMilliseconds(remaining).Humanize(2, minUnit: TimeUnit.Second)} before you can use this command again!");
             
-            MathService.UpdateLatexTimeout(Context.User);
-            
             if (!TryRender(input, out Image originalImage, out string errorMessage))
             {
                 await new EmbedBuilder()
@@ -42,6 +40,8 @@ namespace BrackeysBot.Commands
                      .SendToChannel(Context.Channel);
                 return;
             }
+            
+            MathService.UpdateLatexTimeout(Context.User);
             
             using Image image = AddPadding(originalImage);
             await using Stream stream = GetImageStream(image);


### PR DESCRIPTION
This change introduces a commonly requested QoL improvement, which is to only update the cooldown timeout on successful uses of the []math command.

Benefit:
- Users can re-run the command in the event of a LaTeX syntax error without having to wait 5 minutes to try again

Drawback to consider:
- `MathPainter.DrawAsStream` must still be invoked, in order for the syntax error to be caught in the first place