### PR TITLE
Display month name to prevent confusion

### DIFF
--- a/src/Commands/Modules/Utility/UserInfoCommand.cs
+++ b/src/Commands/Modules/Utility/UserInfoCommand.cs
@@ -37,8 +37,8 @@ namespace BrackeysBot.Commands
                 .AddField("Username", user.ToString(), true)
                 .AddField("ID", user.Id.ToString(), true)
                 .AddFieldConditional(!string.IsNullOrEmpty(user.Nickname), "Nickname", user.Nickname, true)
-                .AddFieldConditional(user.JoinedAt.HasValue, "Join Date", user.JoinedAt?.ToShortDateString(), true)
-                .AddField("User Created", user.CreatedAt.ToShortDateString(), true)
+                .AddFieldConditional(user.JoinedAt.HasValue, "Join Date", user.JoinedAt?.DateTime.ToOrdinalWords(), true)
+                .AddField("User Created", user.CreatedAt.DateTime.ToOrdinalWords(), true)
                 .AddFieldConditional(starCount > 0, "Endorsements", $"{starCount} :star:", true)
                 .AddFieldConditional(infractionCount > 0, "Infractions", infractionCount.ToString(), true)
                 .AddField("Permission Level", user.GetPermissionLevel(Context).Humanize(), true);


### PR DESCRIPTION
Currently, date time is presented in pure numbers. This can create confusion on date-month due to different american-british convention, this commit prints the month name directly.

Keep note that the date depends on the computer locale.
See this result on [dotnetfiddle](https://dotnetfiddle.net):
![image](https://user-images.githubusercontent.com/68814933/117552047-3a131e80-b017-11eb-9fcd-32e5072c6791.png)

And this running from my local computer (American):
![image](https://user-images.githubusercontent.com/68814933/117552059-4a2afe00-b017-11eb-8f3c-677e16fdf280.png)

*However, I haven't put much research into it so I'm not entirely sure. Please confirm this for me.*
