### PR TITLE
Prevent ArgumentException for null/empty reason

### DIFF
--- a/src/Services/ModerationLogService.cs
+++ b/src/Services/ModerationLogService.cs
@@ -77,7 +77,7 @@ namespace BrackeysBot.Services
                 builder.WithFooter($"Infraction ID: {logEntry.InfractionId}");
             
             // First display the Reason, then any additional fields; looks better.
-            builder.AddField("Reason", logEntry.Reason);
+            builder.AddFieldConditional(!string.IsNullOrWhiteSpace(logEntry.Reason), "Reason", logEntry.Reason);
 
             // AddFieldConditional won't work because the logEntry.Duration.Value will be resolved first, which can be a NullReferenceException because
             //  it is not guarantueed Duration will be non-null.


### PR DESCRIPTION
Currently, when `[]unmute` command is used without specifying a reason, the bot throws ArgumentException (though still successfully revokes the Muted role).
![image](https://user-images.githubusercontent.com/1129769/122690046-eb17f600-d21e-11eb-8721-1f7ed475c2c7.png)

This PR resolves the exception by only adding the Reason field to the embed if one is specified.