### PR TITLE
Display username, rather than mention string, for embed author

### DIFF
--- a/src/Services/ModerationLogService.cs
+++ b/src/Services/ModerationLogService.cs
@@ -64,6 +64,7 @@ namespace BrackeysBot.Services
             EmbedBuilder builder = new EmbedBuilder();
 
             StringBuilder author = new StringBuilder($"[{logEntry.ActionType.Humanize()}]");
+            List<string> footnotes = new List<string>();
             
             if (logEntry.HasTarget)
             {
@@ -71,10 +72,15 @@ namespace BrackeysBot.Services
                     author.Append($" {logEntry.Target.Username}#{logEntry.Target.Discriminator}");
                 else
                     author.Append($" {logEntry.TargetID}");
+                
+                footnotes.Add($"User ID: {logEntry.TargetID}");
             }
 
-            if (logEntry.InfractionId > -1) 
-                builder.WithFooter($"Infraction ID: {logEntry.InfractionId}");
+            if (logEntry.InfractionId > -1)
+                footnotes.Add($"Infraction ID: {logEntry.InfractionId}");
+
+            // Split user and infraction ID by bullet point
+            builder.WithFooter(string.Join(" \u2022 ", footnotes));
             
             // First display the Reason, then any additional fields; looks better.
             builder.AddFieldConditional(!string.IsNullOrWhiteSpace(logEntry.Reason), "Reason", logEntry.Reason);

--- a/src/Services/ModerationLogService.cs
+++ b/src/Services/ModerationLogService.cs
@@ -73,7 +73,7 @@ namespace BrackeysBot.Services
                 else
                     author.Append($" {logEntry.TargetID}");
                 
-                footnotes.Add($"User ID: {logEntry.TargetID}");
+                footnotes.Add(logEntry.TargetID.ToString());
             }
 
             if (logEntry.InfractionId > -1)

--- a/src/Services/ModerationLogService.cs
+++ b/src/Services/ModerationLogService.cs
@@ -68,9 +68,9 @@ namespace BrackeysBot.Services
             if (logEntry.HasTarget)
             {
                 if (logEntry.Target != null)
-                    author.Append($" {logEntry.Target.ToString()}");
+                    author.Append($" {logEntry.Target.Username}#{logEntry.Target.Discriminator}");
                 else
-                    author.Append($" {logEntry.TargetMention}");
+                    author.Append($" {logEntry.TargetID}");
             }
 
             if (logEntry.InfractionId > -1) 


### PR DESCRIPTION
Discord only supports mention strings in the description and field values.

This PR fixes the issue where moderation responses use mention string for the embed author as seen here:
![image](https://user-images.githubusercontent.com/1129769/122690493-b35e7d80-d221-11eb-9eb0-a54028f08dae.png)

If available, the user ID is also displayed as part of the embed footer.
If available, the infraction ID is also displayed with a bullet point separator.
![image](https://user-images.githubusercontent.com/1129769/122690419-667aa700-d221-11eb-9acb-70ae72d2f27b.png)
