### PR TITLE
Update ConfigurationCommand.cs

### DIFF
--- a/src/Commands/Modules/Configuration/ConfigurationCommand.cs
+++ b/src/Commands/Modules/Configuration/ConfigurationCommand.cs
@@ -87,7 +87,7 @@ namespace BrackeysBot.Commands
 
                 builder.AddField(new EmbedFieldBuilder()
                     .WithName(values[valueIndex].Name)
-                    .WithValue(LimitFieldLength(values[i].ToString()))
+                    .WithValue(LimitFieldLength(values[valueIndex].ToString()))
                     .WithIsInline(true));
             }
 


### PR DESCRIPTION
Fix a bug that displays the first page fields on the second page of the []config command