### PR TITLE
Fixed a bug that would split links if they had a "SensitiveCharacter"…

### DIFF
--- a/src/Services/CollaborationService.cs
+++ b/src/Services/CollaborationService.cs
@@ -678,7 +678,6 @@ namespace BrackeysBot.Services
                 if (convo.Key == "portfolio")
                 {
                     text = text.Replace("[", "\\[");
-                    Console.WriteLine("sanitized links");
                     return text;
                 }
                 foreach (string unsafeChar in SensitiveCharacters)

--- a/src/Services/CollaborationService.cs
+++ b/src/Services/CollaborationService.cs
@@ -528,7 +528,7 @@ namespace BrackeysBot.Services
                 _collab.DeactivateUser(_message.Author);
                 for (int i = 0; i < _fields.Count; i++)
                 {
-                    _fields[_fields.ElementAt(i).Key] = SanitizeMarkdown(_fields.ElementAt(i).Value);
+                    _fields[_fields.ElementAt(i).Key] = SanitizeMarkdown(_fields.ElementAt(i));
                 }
             }
 
@@ -672,8 +672,15 @@ namespace BrackeysBot.Services
 
                 return string.Join(' ', _portfolioArray);
             }
-            private static string SanitizeMarkdown(string text)
+            private static string SanitizeMarkdown(KeyValuePair<string, string> convo)
             {
+                string text = convo.Value;
+                if (convo.Key == "portfolio")
+                {
+                    text = text.Replace("[", "\\[");
+                    Console.WriteLine("sanitized links");
+                    return text;
+                }
                 foreach (string unsafeChar in SensitiveCharacters)
                     text = text.Replace(unsafeChar, $"\\{unsafeChar}");
                 return text;


### PR DESCRIPTION
… in them

SanitizeMarkdown() method would prefix underscored and other sensitive characters in links with a backslash therefore corrupting the link. Added an if check to only prefix the '[' character for sneaky links.