### PR TITLE
Link filtering added to filter service

### DIFF
--- a/src/Core/Models/Config/BotConfiguration.cs
+++ b/src/Core/Models/Config/BotConfiguration.cs
@@ -123,6 +123,10 @@ namespace BrackeysBot
         [Description("A list of regex for words which should automatically be deleted.")]
         public string[] BlockedWords { get; set; }
         
+        [YamlMember(Alias = "blockedGuildIds")]
+        [Description("A list of guild IDs for guild invites which should automatically be deleted.")]
+        public ulong[] BlockedGuildIds { get; set; }
+
         [YamlMember(Alias = "clearMessageMaxHistory")]
         [Description("The maximum messages history count to fetch when clearing messages.")]
         public int ClearMessageMaxHistory { get; set; }

--- a/src/Services/FilterService.cs
+++ b/src/Services/FilterService.cs
@@ -44,7 +44,7 @@ namespace BrackeysBot.Services
             if (ContainsBlockedWord(content)) 
                 await DeleteMsgAndInfractUser(s as SocketUserMessage, content);
 
-            if (await ContainsBlockedInvite(content))
+            else if (await ContainsBlockedInvite(content))
                 await DeleteMsgAndInfractUser(s as SocketUserMessage, content); // ??
         }
         public async Task CheckEditedMessageAsync(Cacheable<IMessage, ulong> cacheable, SocketMessage s, ISocketMessageChannel channel)

--- a/src/Services/FilterService.cs
+++ b/src/Services/FilterService.cs
@@ -43,6 +43,9 @@ namespace BrackeysBot.Services
             
             if (ContainsBlockedWord(content)) 
                 await DeleteMsgAndInfractUser(s as SocketUserMessage, content);
+
+            if (await ContainsBlockedInvite(content))
+                await DeleteMsgAndInfractUser(s as SocketUserMessage, content); // ??
         }
         public async Task CheckEditedMessageAsync(Cacheable<IMessage, ulong> cacheable, SocketMessage s, ISocketMessageChannel channel)
         {
@@ -60,6 +63,25 @@ namespace BrackeysBot.Services
                 return false;
 
             return blockedWords.Any(str => new Regex($".*{str}.*").IsMatch(msg.ToLowerInvariant()));
+        }
+
+        private async Task<bool> ContainsBlockedInvite(string msg)
+        {
+            const string linkRegex = @"discord(\.gg\/|\.com\/invite\/)\w+";
+            string link = Regex.Match(msg, linkRegex).Value;
+
+            if (link == string.Empty)
+                return false;
+
+            ulong[] blockedGuilds = _dataService.Configuration.BlockedGuildIds;
+            if (blockedGuilds == null)
+                return false;
+
+            var guildInvite = await _discord.GetInviteAsync(link);
+
+            var guildId = guildInvite?.GuildId;
+
+            return blockedGuilds.Any(x => x == guildId);
         }
 
         private bool CanUseFilteredWords(SocketUserMessage msg)


### PR DESCRIPTION
Links to discord channels that are blacklisted will now automatically be deleted and the user will be infracted in the same way how Filter Service works