### PR TITLE
Ignore invalid commands

### DIFF
--- a/src/Services/CommandHandlerService.cs
+++ b/src/Services/CommandHandlerService.cs
@@ -72,11 +72,16 @@ namespace BrackeysBot.Services
                     } 
                     else 
                     {
-                        await new EmbedBuilder()
-                            .WithColor(Color.Red)
-                            .WithDescription($"Command {SanitizeMarkdown(customCommandName)} does not exist!")
-                            .Build()
-                            .SendToChannel(context.Channel);
+                        // Zombie code is my favourite code 🧟
+                        // Nah but seriously, we don't need this anymore because it will conflict with Marco's macro listening.
+                        // But I'd rather not just outright delete it because reasons that I don't really have the energy to list.
+                        // Anyway, here's Wonderwall.
+
+                        // await new EmbedBuilder()
+                        //     .WithColor(Color.Red)
+                        //     .WithDescription($"Command {SanitizeMarkdown(customCommandName)} does not exist!")
+                        //     .Build()
+                        //     .SendToChannel(context.Channel);
                     }
                 }
                 else if (result.Error == CommandError.UnmetPrecondition)


### PR DESCRIPTION
With the introduction of Marco to the server, auto-responses are now handled by a separate bot which uses the same prefix. Therefore the current version of BrackeysBot needs to ignore invalid commands because such commands may exist in another bot.